### PR TITLE
tcti: Add Windows TBS TCTI

### DIFF
--- a/include/tss2/tss2_tcti_tbs.h
+++ b/include/tss2/tss2_tcti_tbs.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2015 - 2018, Intel Corporation
+ * All rights reserved.
+ */
+#ifndef TSS2_TCTI_TBS_H
+#define TSS2_TCTI_TBS_H
+
+#include "tss2_tcti.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+TSS2_RC Tss2_Tcti_Tbs_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TSS2_TCTI_TBS_H */

--- a/lib/tss2-tcti-tbs.def
+++ b/lib/tss2-tcti-tbs.def
@@ -1,0 +1,4 @@
+LIBRARY tss2-tcti-tbs
+EXPORTS
+    Tss2_Tcti_Info
+    Tss2_Tcti_Tbs_Init

--- a/src/tss2-esys/esys_tcti_default.c
+++ b/src/tss2-esys/esys_tcti_default.c
@@ -13,8 +13,12 @@
 #endif /* NO_DL */
 
 #include "tss2_tcti.h"
-#include "tss2_tcti_device.h"
 #include "tss2_tcti_mssim.h"
+#ifdef _WIN32
+#include "tss2_tcti_tbs.h"
+#else /* _WIN32 */
+#include "tss2_tcti_device.h"
+#endif /* else */
 
 #define LOGMODULE esys
 #include "util/log.h"
@@ -36,12 +40,15 @@ struct {
     { "libtss2-tcti-default.so", NULL, "", "Access libtss2-tcti-default.so" },
     { "libtss2-tcti-tabrmd.so", NULL, "", "Access libtss2-tcti-tabrmd.so" },
 #endif /* NO_DL */
-#ifndef _WIN32
+#ifdef _WIN32
+    { .init = Tss2_Tcti_Tbs_Init, .conf = "",
+      .description = "Access to TBS" },
+#else /* _WIN32 */
     { .init = Tss2_Tcti_Device_Init, .conf = "/dev/tpmrm0",
       .description = "Access to /dev/tpmrm0" },
     { .init = Tss2_Tcti_Device_Init, .conf = "/dev/tpm0",
       .description = "Access to /dev/tpm0" },
-#endif /* _WIN32 */
+#endif /* else */
     { .init = Tss2_Tcti_Mssim_Init, .conf = "host=localhost,port=2321",
       .description = "Access to Mssim-simulator for tcp://localhost:2321" },
 };

--- a/src/tss2-esys/tss2-esys.vcxproj
+++ b/src/tss2-esys/tss2-esys.vcxproj
@@ -96,7 +96,7 @@
       <TargetMachine>MachineX86</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;C:\Program Files (x86)\GnuPG\lib\libgcrypt.imp;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;C:\Program Files (x86)\GnuPG\lib\libgcrypt.imp;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -114,7 +114,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;C:\Program Files (x86)\GnuPG\lib\libgcrypt.imp;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;C:\Program Files (x86)\GnuPG\lib\libgcrypt.imp;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -124,7 +124,7 @@
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;NO_DL;strtok_r=strtok_s;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;C:\Program Files\GnuPG\lib\libgcrypt.dll.a;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;C:\Program Files\GnuPG\lib\libgcrypt.dll.a;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -134,7 +134,7 @@
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_USRDLL;TSS2ESYS_EXPORTS;MAXLOGLEVEL=6;NO_DL;strtok_r=strtok_s;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;C:\Program Files\GnuPG\lib\libgcrypt.dll.a;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;$(OutDir)\tss2-sys.lib;$(OutDir)\tss2-tcti-mssim.lib;$(OutDir)\tss2-tcti-tbs.lib;C:\Program Files\GnuPG\lib\libgcrypt.dll.a;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-esys.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/src/tss2-tcti/tcti-tbs.c
+++ b/src/tss2-tcti/tcti-tbs.c
@@ -17,6 +17,7 @@
 
 #include "tcti-common.h"
 #include "tcti-tbs.h"
+
 #define LOGMODULE tcti
 #include "util/log.h"
 
@@ -35,6 +36,7 @@ tcti_tbs_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
     }
     return NULL;
 }
+
 /*
  * This function down-casts the TBS TCTI context to the common context
  * defined in the tcti-common module.
@@ -59,7 +61,7 @@ tcti_tbs_transmit (
     TSS2_RC rc = TSS2_RC_SUCCESS;
     TBS_RESULT tbs_rc;
     /* Reset resSize */
-    tcti_tbs->resSize = TBS_RESULT_MAX_BUFFER_SIZE;
+    tcti_tbs->resSize = sizeof (BYTE) * TBS_RESULT_MAX_BUFFER_SIZE;
 
     if (tcti_tbs == NULL) {
         return TSS2_TCTI_RC_BAD_CONTEXT;
@@ -119,7 +121,7 @@ tcti_tbs_receive (
     }
     if (*response_size < tcti_tbs->resSize) {
         LOG_WARNING ("Caller provided buffer that is not large enough to "
-                  "hold the response buffer.");
+                     "hold the response buffer.");
         rc = TSS2_TCTI_RC_BAD_VALUE;
         goto out;
     }
@@ -133,6 +135,7 @@ tcti_tbs_receive (
     if (rc != TSS2_RC_SUCCESS) {
         goto out;
     }
+
     /*
      * Executing code beyond this point transitions the state machine to
      * TRANSMIT. Another call to this function will not be possible until
@@ -221,9 +224,10 @@ Tss2_Tcti_Tbs_Init (
     TBS_CONTEXT_PARAMS2 params;
     TPM_DEVICE_INFO info;
 
-    if (tctiContext == NULL && size == NULL) {
-        return TSS2_TCTI_RC_BAD_VALUE;
-    } else if (tctiContext == NULL) {
+    if (tctiContext == NULL) {
+        if (size == NULL) {
+            return TSS2_TCTI_RC_BAD_VALUE;
+        }
         *size = sizeof (TSS2_TCTI_TBS_CONTEXT);
         return TSS2_RC_SUCCESS;
     }
@@ -241,6 +245,7 @@ Tss2_Tcti_Tbs_Init (
     tcti_tbs = tcti_tbs_context_cast (tctiContext);
     tcti_common = tcti_tbs_down_cast (tcti_tbs);
     tcti_common->state = TCTI_STATE_TRANSMIT;
+
     memset (&tcti_common->header, 0, sizeof (tcti_common->header));
     tcti_common->locality = 0;
 

--- a/src/tss2-tcti/tcti-tbs.c
+++ b/src/tss2-tcti/tcti-tbs.c
@@ -1,0 +1,286 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2015 - 2018 Intel Corporation
+ * All rights reserved.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <windows.h>
+#include <Tbs.h>
+
+#include "tss2_tcti.h"
+#include "tss2_tcti_tbs.h"
+
+#include "tcti-common.h"
+#include "tcti-tbs.h"
+#define LOGMODULE tcti
+#include "util/log.h"
+
+/*
+ * This function wraps the "up-cast" of the opaque TCTI context type to the
+ * type for the TBS TCTI context. The only safe-guard we have to ensure
+ * this operation is possible is the magic number for the TBS TCTI context.
+ * If passed a NULL context, or the magic number check fails, this function
+ * will return NULL.
+ */
+TSS2_TCTI_TBS_CONTEXT*
+tcti_tbs_context_cast (TSS2_TCTI_CONTEXT *tcti_ctx)
+{
+    if (tcti_ctx != NULL && TSS2_TCTI_MAGIC (tcti_ctx) == TCTI_TBS_MAGIC) {
+        return (TSS2_TCTI_TBS_CONTEXT*)tcti_ctx;
+    }
+    return NULL;
+}
+/*
+ * This function down-casts the TBS TCTI context to the common context
+ * defined in the tcti-common module.
+ */
+TSS2_TCTI_COMMON_CONTEXT*
+tcti_tbs_down_cast (TSS2_TCTI_TBS_CONTEXT *tcti_tbs)
+{
+    if (tcti_tbs == NULL) {
+        return NULL;
+    }
+    return &tcti_tbs->common;
+}
+
+TSS2_RC
+tcti_tbs_transmit (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t command_size,
+    const uint8_t *command_buffer)
+{
+    TSS2_TCTI_TBS_CONTEXT *tcti_tbs = tcti_tbs_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_tbs_down_cast (tcti_tbs);
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+    TBS_RESULT tbs_rc;
+    /* Reset resSize */
+    tcti_tbs->resSize = TBS_RESULT_MAX_BUFFER_SIZE;
+
+    if (tcti_tbs == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    rc = tcti_common_transmit_checks (tcti_common, command_buffer);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    LOGBLOB_DEBUG (command_buffer,
+                   command_size,
+                   "sending %zu byte command buffer:",
+                   command_size);
+    tbs_rc = Tbsip_Submit_Command (tcti_tbs->hContext,
+                                   TBS_COMMAND_LOCALITY_ZERO,
+                                   TBS_COMMAND_PRIORITY_NORMAL,
+                                   command_buffer,
+                                   command_size,
+                                   tcti_tbs->resultBuffer,
+                                   &(tcti_tbs->resSize)
+    );
+    if (tbs_rc != TBS_SUCCESS) {
+        LOG_ERROR ("Failed to submit command to TBS with error: 0x%x", tbs_rc);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    tcti_common->state = TCTI_STATE_RECEIVE;
+    return TSS2_RC_SUCCESS;
+}
+
+TSS2_RC
+tcti_tbs_receive (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *response_size,
+    uint8_t *response_buffer,
+    int32_t timeout)
+{
+    TSS2_TCTI_TBS_CONTEXT *tcti_tbs = tcti_tbs_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_tbs_down_cast (tcti_tbs);
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+
+    if (tcti_tbs == NULL) {
+        return TSS2_TCTI_RC_BAD_CONTEXT;
+    }
+    rc = tcti_common_receive_checks (tcti_common, response_size);
+    if (rc != TSS2_RC_SUCCESS) {
+        return rc;
+    }
+    if (timeout != TSS2_TCTI_TIMEOUT_BLOCK) {
+        LOG_WARNING ("The underlying IPC mechanism does not support "
+                     "asynchronous I/O. The 'timeout' parameter must be "
+                     "TSS2_TCTI_TIMEOUT_BLOCK");
+        return TSS2_TCTI_RC_BAD_VALUE;
+    }
+    if (response_buffer == NULL) {
+        *response_size = tcti_tbs->resSize;
+        return TSS2_RC_SUCCESS;
+    }
+    if (*response_size < tcti_tbs->resSize) {
+        LOG_WARNING ("Caller provided buffer that is not large enough to "
+                  "hold the response buffer.");
+        rc = TSS2_TCTI_RC_BAD_VALUE;
+        goto out;
+    }
+    if (tcti_tbs->resSize == 0 || tcti_tbs->resSize > TBS_RESULT_MAX_BUFFER_SIZE) {
+        LOG_WARNING ("The size of the response buffer is invalid, resSize=%d", tcti_tbs->resSize);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+    memcpy (response_buffer, tcti_tbs->resultBuffer, tcti_tbs->resSize);
+    LOGBLOB_DEBUG (response_buffer, tcti_tbs->resSize, "Response Received");
+    rc = header_unmarshal (response_buffer, &tcti_common->header);
+    if (rc != TSS2_RC_SUCCESS) {
+        goto out;
+    }
+    /*
+     * Executing code beyond this point transitions the state machine to
+     * TRANSMIT. Another call to this function will not be possible until
+     * another command is sent to the TPM.
+     */
+out:
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    tcti_tbs->resSize = 0;
+    return rc;
+}
+
+void
+tcti_tbs_finalize (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    TSS2_TCTI_TBS_CONTEXT *tcti_tbs = tcti_tbs_context_cast (tctiContext);
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common = tcti_tbs_down_cast (tcti_tbs);
+    TBS_RESULT tbs_rc;
+
+    if (tcti_tbs == NULL) {
+        return;
+    }
+
+    free (tcti_tbs->resultBuffer);
+
+    tbs_rc = Tbsip_Context_Close (tcti_tbs->hContext);
+    if (tbs_rc != TBS_SUCCESS) {
+        LOG_WARNING ("Failed to close context with TBS error: 0x%x", tbs_rc);
+    }
+
+    tcti_common->state = TCTI_STATE_FINAL;
+}
+
+TSS2_RC
+tcti_tbs_cancel (
+    TSS2_TCTI_CONTEXT *tctiContext)
+{
+    TBS_RESULT tbs_rc;
+    TSS2_RC rc = TSS2_RC_SUCCESS;
+    TSS2_TCTI_TBS_CONTEXT *tcti_tbs = tcti_tbs_context_cast (tctiContext);
+
+    tbs_rc = Tbsip_Cancel_Commands (tcti_tbs->hContext);
+    if (tbs_rc != TBS_SUCCESS) {
+        LOG_WARNING ("Failed to cancel commands with TBS error: 0x%x", tbs_rc);
+        rc = TSS2_TCTI_RC_GENERAL_FAILURE;
+    }
+
+    return rc;
+}
+
+TSS2_RC
+tcti_tbs_get_poll_handles (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    TSS2_TCTI_POLL_HANDLE *handles,
+    size_t *num_handles)
+{
+    /* TBS doesn't support polling. */
+    (void)(tctiContext);
+    (void)(handles);
+    (void)(num_handles);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+tcti_tbs_set_locality (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    uint8_t locality)
+{
+    /*
+     * TBS currently only supports locality 0
+     */
+    (void)(tctiContext);
+    (void)(locality);
+    return TSS2_TCTI_RC_NOT_IMPLEMENTED;
+}
+
+TSS2_RC
+Tss2_Tcti_Tbs_Init (
+    TSS2_TCTI_CONTEXT *tctiContext,
+    size_t *size,
+    const char *conf)
+{
+    TSS2_TCTI_TBS_CONTEXT *tcti_tbs;
+    TSS2_TCTI_COMMON_CONTEXT *tcti_common;
+    TBS_RESULT tbs_rc;
+    TBS_CONTEXT_PARAMS2 params;
+    TPM_DEVICE_INFO info;
+
+    if (tctiContext == NULL && size == NULL) {
+        return TSS2_TCTI_RC_BAD_VALUE;
+    } else if (tctiContext == NULL) {
+        *size = sizeof (TSS2_TCTI_TBS_CONTEXT);
+        return TSS2_RC_SUCCESS;
+    }
+
+    /* Init TCTI context */
+    TSS2_TCTI_MAGIC (tctiContext) = TCTI_TBS_MAGIC;
+    TSS2_TCTI_VERSION (tctiContext) = TCTI_VERSION;
+    TSS2_TCTI_TRANSMIT (tctiContext) = tcti_tbs_transmit;
+    TSS2_TCTI_RECEIVE (tctiContext) = tcti_tbs_receive;
+    TSS2_TCTI_FINALIZE (tctiContext) = tcti_tbs_finalize;
+    TSS2_TCTI_CANCEL (tctiContext) = tcti_tbs_cancel;
+    TSS2_TCTI_GET_POLL_HANDLES (tctiContext) = tcti_tbs_get_poll_handles;
+    TSS2_TCTI_SET_LOCALITY (tctiContext) = tcti_tbs_set_locality;
+    TSS2_TCTI_MAKE_STICKY (tctiContext) = tcti_make_sticky_not_implemented;
+    tcti_tbs = tcti_tbs_context_cast (tctiContext);
+    tcti_common = tcti_tbs_down_cast (tcti_tbs);
+    tcti_common->state = TCTI_STATE_TRANSMIT;
+    memset (&tcti_common->header, 0, sizeof (tcti_common->header));
+    tcti_common->locality = 0;
+
+    params.includeTpm20 = 1;
+    params.version = TBS_CONTEXT_VERSION_TWO;
+    tbs_rc = Tbsi_Context_Create ((PCTBS_CONTEXT_PARAMS)&params, &(tcti_tbs->hContext));
+    if (tbs_rc != TBS_SUCCESS) {
+        LOG_WARNING ("Failed to create context with TBS error: 0x%x", tbs_rc);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    tbs_rc = Tbsi_GetDeviceInfo (sizeof (info), &info);
+    if (tbs_rc != TBS_SUCCESS) {
+        LOG_WARNING ("Failed to get device information with TBS error: 0x%x", tbs_rc);
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+    if (info.tpmVersion != TPM_VERSION_20) {
+        LOG_WARNING ("Failed to create context, TPM version is incorrect");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    tcti_tbs->resultBuffer = malloc (sizeof (BYTE) * TBS_RESULT_MAX_BUFFER_SIZE);
+    if (tcti_tbs->resultBuffer == NULL) {
+        LOG_WARNING ("Failed to allocate memory for the result buffer when creating context");
+        return TSS2_TCTI_RC_IO_ERROR;
+    }
+
+    return TSS2_RC_SUCCESS;
+}
+
+const TSS2_TCTI_INFO tss2_tcti_info = {
+    .version = TCTI_VERSION,
+    .name = "tcti-tbs",
+    .description = "TCTI module for communication with Windows TPM Base Services",
+    .config_help = "Configuration is not used",
+    .init = Tss2_Tcti_Tbs_Init,
+};
+
+const TSS2_TCTI_INFO*
+Tss2_Tcti_Info (void)
+{
+    return &tss2_tcti_info;
+}

--- a/src/tss2-tcti/tcti-tbs.h
+++ b/src/tss2-tcti/tcti-tbs.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2 */
+/*
+ * Copyright (c) 2018 Intel Corporation
+ * All rights reserved.
+ */
+#ifndef TCTI_TBS_H
+#define TCTI_TBS_H
+
+#include "tcti-common.h"
+
+#define TBS_RESULT_MAX_BUFFER_SIZE 8192
+#define TCTI_TBS_MAGIC 0xfbf2afa3761e188aULL
+
+typedef struct {
+    TSS2_TCTI_COMMON_CONTEXT common;
+    void *hContext;
+    PBYTE resultBuffer;
+    UINT32 resSize;
+} TSS2_TCTI_TBS_CONTEXT;
+
+
+
+#endif /* TCTI_TBS_H */

--- a/src/tss2-tcti/tss2-tcti-tbs.sln
+++ b/src/tss2-tcti/tss2-tcti-tbs.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2026
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-tcti-tbs", "tss2-tcti-tbs.vcxproj", "{6BA6146F-8B38-49A2-A156-769E0F2CC302}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x64.ActiveCfg = Debug|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x64.Build.0 = Debug|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x86.ActiveCfg = Debug|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x86.Build.0 = Debug|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x64.ActiveCfg = Release|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x64.Build.0 = Release|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x86.ActiveCfg = Release|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EEA2CEAA-E358-4281-A26E-B4E03BB61635}
+	EndGlobalSection
+EndGlobal

--- a/src/tss2-tcti/tss2-tcti-tbs.vcxproj
+++ b/src/tss2-tcti/tss2-tcti-tbs.vcxproj
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{6BA6146F-8B38-49A2-A156-769E0F2CC302}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)\$(Configuration)\$(Platform)\</OutDir>
+    <IntDir>$(SolutionDir)\$(Configuration)\$(Platform)\</IntDir>
+    <TargetExt>.dll</TargetExt>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;MAXLOGLEVEL=6;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;Tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-tbs.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;MAXLOGLEVEL=6;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;Tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-tbs.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_WINDLL;MAXLOGLEVEL=6;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;Tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-tbs.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src;$(SolutionDir)\include\tss2;$(SolutionDir)\src\tss2-mu;$(SolutionDir)\src\tss2-sys;(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_WINDLL;MAXLOGLEVEL=6;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(OutDir)\tss2-mu.lib;Tbs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ModuleDefinitionFile>$(SolutionDir)\lib\tss2-tcti-tbs.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\util\log.c" />
+    <ClCompile Include="tcti-common.c" />
+    <ClCompile Include="tcti-tbs.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\util\log.h" />
+    <ClInclude Include="tcti-common.h" />
+    <ClInclude Include="tcti-tbs.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/tss2-tcti/tss2-tcti-tbs.vcxproj.filters
+++ b/src/tss2-tcti/tss2-tcti-tbs.vcxproj.filters
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="tcti-common.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="tcti-tbs.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\util\log.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="tcti-common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="tcti-tbs.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\util\log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/tpm2-tss.sln
+++ b/tpm2-tss.sln
@@ -19,8 +19,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-esys", "src\tss2-esys\
 	ProjectSection(ProjectDependencies) = postProject
 		{10D9862F-0E36-4ACC-AF19-930B00A88A98} = {10D9862F-0E36-4ACC-AF19-930B00A88A98}
 		{A6D8F061-6827-492F-80C3-32C4DD4FC52E} = {A6D8F061-6827-492F-80C3-32C4DD4FC52E}
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302} = {6BA6146F-8B38-49A2-A156-769E0F2CC302}
 		{89B6B774-2886-48CF-B1D0-534AC449E0FD} = {89B6B774-2886-48CF-B1D0-534AC449E0FD}
 	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "tss2-tcti-tbs", "src\tss2-tcti\tss2-tcti-tbs.vcxproj", "{6BA6146F-8B38-49A2-A156-769E0F2CC302}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,6 +65,14 @@ Global
 		{BE0516D7-994C-4133-BD91-A21239D8B087}.Release|x64.Build.0 = Release|x64
 		{BE0516D7-994C-4133-BD91-A21239D8B087}.Release|x86.ActiveCfg = Release|Win32
 		{BE0516D7-994C-4133-BD91-A21239D8B087}.Release|x86.Build.0 = Release|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x64.ActiveCfg = Debug|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x64.Build.0 = Debug|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x86.ActiveCfg = Debug|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Debug|x86.Build.0 = Debug|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x64.ActiveCfg = Release|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x64.Build.0 = Release|x64
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x86.ActiveCfg = Release|Win32
+		{6BA6146F-8B38-49A2-A156-769E0F2CC302}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add a TBS TCTI, this allows the tss libraries to interact with physical
TPM devices on Windows.

Add a Visual Studio solution to build the TBS TCTI Library.

Change esys_tcti_default to include the TBS TCTI when building on
Windows.

Signed-off-by: David Maria <davidjmaria@fb.com>